### PR TITLE
Set default value of target for zone

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -138,7 +138,7 @@ class firewalld::zone::base (
 #      },],}
 #
 define firewalld::zone(
-  $target = '',
+  $target = '%%REJECT%%',
   $short = '',
   $description = '',
   $interfaces = [],


### PR DESCRIPTION
According to the comments, target should have a default value of reject.

Fixes #15 