### PR TITLE
Add zone target parameter validation

### DIFF
--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -70,6 +70,7 @@ Puppet::Type.newtype(:firewalld_zone) do
       doesn't match any rule (port, service, etc.).
       Default (when target is not specified) is reject.
     EOT
+    newvalues('ACCEPT', '%%REJECT%%', 'DROP')
   end
 
   newparam(:short) do

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -138,7 +138,7 @@ class firewalld::zone::base (
 #      },],}
 #
 define firewalld::zone(
-  $target = '',
+  $target = undef,
   $short = '',
   $description = '',
   $interfaces = [],


### PR DESCRIPTION
To prevent invalid zone definition, the zone's target attribute needs
to be validated. Furthermore not specifying the target at all needs to
be possible, so firewalld applies the default target
'{chain}_ZONE_{zone}'.