### PR TITLE
Add validation for zone names

### DIFF
--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -60,7 +60,15 @@ Puppet::Type.newtype(:firewalld_zone) do
   ensurable
 
   newparam(:name) do
-      desc "The name of the zone"
+    desc "The name of the zone"
+    validate do |value|
+      unless value =~ /^[A-Za-z0-9_]+$/
+        raise(ArgumentError, "Invalid zone name: #{name}") 
+      end
+      if value.length > 17
+        raise(ArgumentError, "Zone name longer than 17 characters: #{name}")
+      end
+    end
   end 
 
   newparam(:target) do


### PR DESCRIPTION
Valid names for zones are very limited, because they end up as
Netfilter target names. To prevent misconfigured firewalls, zone names
need to be validated.