### PR TITLE
Fix json syntax in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -24,9 +24,9 @@
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
         "20",
-        "21",
+        "21"
       ]
-    },
+    }
   ],
   "requirements": [
     {


### PR DESCRIPTION
There was an extra comma and a missing comma in the metadata.json file.  This fixes those errors.