### PR TITLE
solve dependency issue with rich rule

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,5 +48,13 @@ class firewalld {
       Service['iptables', 'ip6tables'],  # ensure it's stopped
     ],
   }
+
+  exec{ 'firewalld::reload':
+    path        =>'/usr/bin:/bin',
+    command     => 'firewall-cmd --complete-reload',
+    refreshonly => true,
+  }
+
   Service['firewalld'] -> Firewalld_zone<||>
+
 }

--- a/manifests/rich_rule.pp
+++ b/manifests/rich_rule.pp
@@ -48,6 +48,7 @@ define firewalld::rich_rule(
     ensure     => $ensure,
     zone       => $zone,
     rich_rules => $rich_rules,
-    notify     => Service['firewalld']
+    notify     => Exec['firewalld::reload'],
+    require    => Firewalld_zone[$zone],
   }
 }


### PR DESCRIPTION
rich rules need the zone to be available, this caused dependency cycle so I've added the firewalld::reload resource (from https://github.com/crayfishx/puppet-firewalld).

Now you are able to add a rich rule to a custom zone and let puppet manage the whole thing.