### PR TITLE
Reload the service rather than restart the service

### DIFF
--- a/manifests/configuration.pp
+++ b/manifests/configuration.pp
@@ -64,7 +64,7 @@ class firewalld::configuration (
     group   => root,
     mode    => '0750',
     require => Package['firewalld'], # make sure package is installed
-    notify  => Service['firewalld'], # restart service
+    notify  => Exec['firewalld::reload'], # reload service
   }
 
   file { '/etc/firewalld/firewalld.conf':

--- a/manifests/configuration.pp
+++ b/manifests/configuration.pp
@@ -74,6 +74,6 @@ class firewalld::configuration (
     group   => root,
     mode    => '0640',
     require => Package['firewalld'], # make sure package is installed
-    notify  => Service['firewalld'], # restart service
+    notify  => Exec['firewalld::reload'], # reload service
   }
 }

--- a/manifests/direct.pp
+++ b/manifests/direct.pp
@@ -89,6 +89,6 @@ class firewalld::direct(
     group   => root,
     mode    => '0644',
     require => Package['firewalld'],
-    notify  => Service['firewalld'],
+    notify  => Exec['firewalld::reload'], # reload service
   }
 }

--- a/manifests/lockdown_whitelist.pp
+++ b/manifests/lockdown_whitelist.pp
@@ -63,6 +63,6 @@ class firewalld::lockdown_whitelist(
       group   => root,
       mode    => '0644',
       require => Package['firewalld'],
-      notify  => Service['firewalld'],
+      notify  => Exec['firewalld::reload'], # reload service
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -64,6 +64,6 @@ define firewalld::service(
     group   => root,
     mode    => '0644',
     require => Package['firewalld'],
-    notify  => Service['firewalld'],
+    notify  => Exec['firewalld::reload'], # reload service
   }
 }

--- a/manifests/service/base.pp
+++ b/manifests/service/base.pp
@@ -30,6 +30,6 @@ class firewalld::service::base {
     group   => root,
     mode    => '0750',
     require => Package['firewalld'],
-    notify  => Service['firewalld'],
+    notify  => Exec['firewalld::reload'], # reload service
   }
 }

--- a/manifests/zone/base.pp
+++ b/manifests/zone/base.pp
@@ -32,6 +32,6 @@ class firewalld::zone::base (
     group   => root,
     mode    => '0750',
     require => Package['firewalld'],
-    notify  => Service['firewalld'],
+    notify  => Exec['firewalld::reload'], # reload service
   }
 }


### PR DESCRIPTION
During Puppet runs, Puppet tried to reload the service while it was still in the process of restarting. I updated the code to just reload the service after configuration changes.